### PR TITLE
Change port to int type

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -80,7 +80,7 @@ class Database(object):
 
     @classmethod
     def connect(cls, **db_config):
-        cls.conn = MySQLdb.connect(host=db_config.get('host', 'localhost'), port=db_config.get('port', 3306),
+        cls.conn = MySQLdb.connect(host=db_config.get('host', 'localhost'), port=int(db_config.get('port', 3306)),
                                    user=db_config.get('user', 'root'), passwd=db_config.get('password', ''),
                                    db=db_config.get('database', 'test'), charset=db_config.get('charset', 'utf8'))
         cls.conn.autocommit(cls.autocommit)


### PR DESCRIPTION
while user has configed the port in a file instead of writing directly in a dictionary, the port is  in string type,  then MySQLdb will raise an error, therefor, it is necessary to enforce the port type to int..
